### PR TITLE
Feature Laravel 10 & Optional GuzzleConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Improvements:
 * Added `$guzzleConfig` to the `Connector`constructor
 * Added `$guzzleConfig` to the `Client`constructor
 * Added `illuminate/config && illuminate/support` version 10 in the `Composer.json`
+* updated setFindQueryAll in FmBaseRepository
 
 
 # 2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.1.0
+Improvements:
+* Added `$guzzleConfig` to the `Connector`constructor
+* Added `$guzzleConfig` to the `Client`constructor
+* Added `illuminate/config && illuminate/support` version 10 in the `Composer.json`
+
+
 # 2.0.2
 Fixed retrieval of container field data, with session token.
 

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": ">=8.0",
         "guzzlehttp/guzzle": "^7.4.5|^7.5",
-        "illuminate/config": "^7.0|^8.0|^9.0",
-        "illuminate/support": "^7.0|^8.0|^9.0",
+        "illuminate/config": "^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
         "nesbot/carbon": "^2.17"
     },
     "config": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,17 +4,16 @@
 namespace Flooris\FileMakerDataApi;
 
 
-use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Str;
 use Psr\Http\Message\StreamInterface;
-use GuzzleHttp\Exception\GuzzleException;
-use Psr\SimpleCache\InvalidArgumentException;
-use Illuminate\Contracts\Cache\Repository as CacheRepositoryInterface;
-use Flooris\FileMakerDataApi\Api\Authentication;
-use Flooris\FileMakerDataApi\Api\MetaData;
 use Flooris\FileMakerDataApi\Api\Record;
 use Flooris\FileMakerDataApi\Api\Script;
+use GuzzleHttp\Exception\GuzzleException;
+use Flooris\FileMakerDataApi\Api\MetaData;
+use Psr\SimpleCache\InvalidArgumentException;
+use Flooris\FileMakerDataApi\Api\Authentication;
 use Flooris\FileMakerDataApi\HttpClient\Connector;
-use Illuminate\Support\Str;
+use Illuminate\Contracts\Cache\Repository as CacheRepositoryInterface;
 
 class Client
 {
@@ -26,11 +25,12 @@ class Client
     public function __construct(
         protected CacheRepositoryInterface $cache,
         public string                      $configHost = "default",
-        public ?Connector                  $connector = null
+        public ?Connector                  $connector = null,
+        array                              $guzzleConfig = []
     )
     {
         if ($this->connector === null) {
-            $this->connector = new Connector($configHost, $cache);
+            $this->connector = new Connector($configHost, $cache, $guzzleConfig);
         }
 
         if ($this->connector->hasValidConnectionCredentials()) {

--- a/src/HttpClient/Connector.php
+++ b/src/HttpClient/Connector.php
@@ -3,14 +3,14 @@
 
 namespace Flooris\FileMakerDataApi\HttpClient;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\StreamInterface;
-use GuzzleHttp\Exception\GuzzleException;
-use Illuminate\Contracts\Cache\Repository as CacheRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Exception\GuzzleException;
 use Psr\SimpleCache\InvalidArgumentException;
 use Flooris\FileMakerDataApi\Client as FmClient;
-use GuzzleHttp\RequestOptions;
-use GuzzleHttp\Client;
+use Illuminate\Contracts\Cache\Repository as CacheRepositoryInterface;
 use Flooris\FileMakerDataApi\Exceptions\FilemakerDataApiConfigHostMissingException;
 use Flooris\FileMakerDataApi\Exceptions\FilemakerDataApiConfigInvalidConnectionException;
 
@@ -21,7 +21,8 @@ class Connector
 
     public function __construct(
         private string                     $configHost,
-        protected CacheRepositoryInterface $cache
+        protected CacheRepositoryInterface $cache,
+        array  $guzzleConfig  = []
     )
     {
         $this->baseUrl = $this->getBaseUri();
@@ -30,9 +31,9 @@ class Connector
             return;
         }
 
-        $this->guzzleClient = new Client([
+        $this->guzzleClient = new Client(array_merge([
             'base_uri' => $this->baseUrl,
-        ]);
+          ], $guzzleConfig));
     }
 
     public function get(string $uri, ?string $sessionToken = null, array $query = []): ResponseInterface

--- a/src/RecordRepository/FmBaseRepository.php
+++ b/src/RecordRepository/FmBaseRepository.php
@@ -116,9 +116,11 @@ abstract class FmBaseRepository
         ];
     }
 
-    public function setFindQueryAll(array $findQuery): void
+    public function setFindQueryAll(array $findQuery): self
     {
         $this->findQueryAll = $findQuery;
+
+        return $this;
     }
 
     public function getTotalRecordCount(): int


### PR DESCRIPTION
# Feature Laravel 10 & Optional GuzzleConfig

## Description
The current version has no support for laravel 10. 
Beside that issue you can also not make any changes to the guzzle config. 
Which means you can not enforce your own custom guzzle configs.

In this Fork there is laravel 10 support added. And you can also pass along an optional guzzle config.

## Changes
- updated so that the client and connector can take an array for guzzle config
- updated composer.json to support the required newer version of laravel 10 dependencies.
- updated changelog for new version release
- updated setFindQueryAll in FmBaseRepository