### PR TITLE
Feature Sort array on findRecords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+# 2.2.0
+Improvements:
+* Added `$sort` parameter to findRecords on `FmBaseRepository`
 # 2.1.0
 Improvements:
 * Added `$guzzleConfig` to the `Connector`constructor

--- a/src/RecordRepository/FmBaseRepository.php
+++ b/src/RecordRepository/FmBaseRepository.php
@@ -51,13 +51,13 @@ abstract class FmBaseRepository
         return null;
     }
 
-    public function findRecords(array $findQuery, int $offset = 1, int $limit = 100): ?array
+    public function findRecords(array $findQuery, int $offset = 1, int $limit = 100, array $sort = []): ?array
     {
         try {
             $result = $this
                 ->fmClient
                 ->record($this->fmLayoutName)
-                ->findRecords($findQuery, $offset, $limit);
+                ->findRecords($findQuery, $offset, $limit, $sort);
         } catch (\Exception|InvalidArgumentException $exception) {
             $this->findRequestFailed = true;
             $this->lastException     = $exception;


### PR DESCRIPTION
## Description
ability to sort by fields when requesting records

## Changes
- findRecords now has sort paramter which is an empty array by default
- updated changelog for new suggested version with change