### PR TITLE
Date format and session ttl support from configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-
+# 2.2.1
+Improvements:
+* Added control over date formatting expectations and the TTL of a session token through the config
+* Added function on the client for retrieving TTL value for the token
+# 2.2.0
+Improvements:
+* Added `$sort` parameter to findRecords on `FmBaseRepository`
 # 2.2.0
 Improvements:
 * Added `$sort` parameter to findRecords on `FmBaseRepository`

--- a/config/filemaker.php
+++ b/config/filemaker.php
@@ -14,5 +14,7 @@ return [
     ],
     'settings' => [
         'boolean_true_values' => ['true', '1', 'yes', 'y', 'j', 'ja'],
+        'date_format'         => env('FM_DATE_FORMAT', 'm-d-Y'),
+        'session_ttl'         => env('FM_SESSION_TTL', 900),
     ],
 ];

--- a/config/filemaker.php
+++ b/config/filemaker.php
@@ -15,6 +15,6 @@ return [
     'settings' => [
         'boolean_true_values' => ['true', '1', 'yes', 'y', 'j', 'ja'],
         'date_format'         => env('FM_DATE_FORMAT', 'm-d-Y'),
-        'session_ttl'         => env('FM_SESSION_TTL', 900),
+        'session_ttl'         => env('FM_SESSION_TTL', 400),
     ],
 ];

--- a/src/Api/Record.php
+++ b/src/Api/Record.php
@@ -73,8 +73,8 @@ class Record extends ApiAbstract
             '_limit'  => $limit,
         ];
 
-        if (is_array($sort) && !empty($sort)) {
-            if (! isset($sort[0]) || !is_array($sort[0])) {
+        if (is_array($sort) && ! empty($sort)) {
+            if (! isset($sort[0]) || ! is_array($sort[0])) {
                 $sort = [$sort]; // This is required as FileMaker expects an array
             }
 
@@ -102,8 +102,8 @@ class Record extends ApiAbstract
             'offset' => $offset,
         ];
 
-        if (is_array($sort) && !empty($sort)) {
-            if (! isset($sort[0]) || !is_array($sort[0])) {
+        if (is_array($sort) && ! empty($sort)) {
+            if (! isset($sort[0]) || ! is_array($sort[0])) {
                 $sort = [$sort]; // This is required as FileMaker expects an array
             }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -98,7 +98,7 @@ class Client
 
     public function getSessionTokenCacheKey(): string
     {
-        return sprintf('filemaker.%s.session_token', $this->configHost);;
+        return sprintf('filemaker.%s.session_token', $this->configHost);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@
 namespace Flooris\FileMakerDataApi;
 
 
+use Exception;
 use Illuminate\Support\Str;
 use Psr\Http\Message\StreamInterface;
 use Flooris\FileMakerDataApi\Api\Record;
@@ -65,7 +66,7 @@ class Client
 
     /**
      * @throws InvalidArgumentException
-     * @throws \Exception
+     * @throws Exception
      */
     public function validateSession(): void
     {
@@ -76,7 +77,8 @@ class Client
         }
     }
 
-    private function sessionTTL(): int {
+    private function sessionTTL(): int
+    {
         return (int)config('filemaker.settings.session_ttl');
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -76,6 +76,10 @@ class Client
         }
     }
 
+    private function sessionTTL(): int {
+        return (int)config('filemaker.settings.session_ttl');
+    }
+
     /**
      * @throws InvalidArgumentException
      */
@@ -112,7 +116,7 @@ class Client
 
         $cacheKey = $this->getSessionTokenCacheKey();
 
-        $this->cache->set($cacheKey, $sessionToken, 60 * 15);
+        $this->cache->set($cacheKey, $sessionToken, $this->sessionTTL());
     }
 
     /**

--- a/src/Exceptions/FilemakerDataApiConfigHostMissingException.php
+++ b/src/Exceptions/FilemakerDataApiConfigHostMissingException.php
@@ -2,7 +2,9 @@
 
 namespace Flooris\FileMakerDataApi\Exceptions;
 
-class FilemakerDataApiConfigHostMissingException extends \Exception
+use Exception;
+
+class FilemakerDataApiConfigHostMissingException extends Exception
 {
     public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
     {

--- a/src/Exceptions/FilemakerDataApiConfigInvalidConnectionException.php
+++ b/src/Exceptions/FilemakerDataApiConfigInvalidConnectionException.php
@@ -2,7 +2,9 @@
 
 namespace Flooris\FileMakerDataApi\Exceptions;
 
-class FilemakerDataApiConfigInvalidConnectionException extends \Exception
+use Exception;
+
+class FilemakerDataApiConfigInvalidConnectionException extends Exception
 {
     public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
     {

--- a/src/Exceptions/FilemakerDataApiConfigInvalidException.php
+++ b/src/Exceptions/FilemakerDataApiConfigInvalidException.php
@@ -2,7 +2,9 @@
 
 namespace Flooris\FileMakerDataApi\Exceptions;
 
-class FilemakerDataApiConfigInvalidException extends \Exception
+use Exception;
+
+class FilemakerDataApiConfigInvalidException extends Exception
 {
     public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
     {

--- a/src/FileMakerDataApiServiceProvider.php
+++ b/src/FileMakerDataApiServiceProvider.php
@@ -9,14 +9,14 @@ class FileMakerDataApiServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->publishes([
-            __DIR__.'/../config/filemaker.php' => config_path('filemaker.php'),
+            __DIR__ . '/../config/filemaker.php' => config_path('filemaker.php'),
         ], 'filemaker-data-api');
     }
 
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/filemaker.php', 'filemaker'
+            __DIR__ . '/../config/filemaker.php', 'filemaker'
         );
     }
 }

--- a/src/HttpClient/Connector.php
+++ b/src/HttpClient/Connector.php
@@ -82,19 +82,16 @@ class Connector
      */
     public function getDataContainerContent(string $dataContainerObjectUrl, string $dataContainerToken): ?StreamInterface
     {
-        $options = [
+
+        $options = array_merge([
             RequestOptions::HEADERS => [
                 'Cookie' => [
                     $dataContainerToken,
                 ],
             ],
-        ];
+        ], $this->guzzleConfig);
 
-        $client = new Client([
-            'base_uri' => $dataContainerObjectUrl,
-        ]);
-
-        $response = $client->request('GET', '', $options);
+        $response = $this->guzzleClient->request('GET', $dataContainerObjectUrl, $options);
 
         return $response->getBody();
     }

--- a/src/HttpClient/Connector.php
+++ b/src/HttpClient/Connector.php
@@ -22,7 +22,7 @@ class Connector
     public function __construct(
         private string                     $configHost,
         protected CacheRepositoryInterface $cache,
-        array  $guzzleConfig  = []
+        private array  $guzzleConfig  = []
     )
     {
         $this->baseUrl = $this->getBaseUri();
@@ -58,16 +58,12 @@ class Connector
 
     public function getDataContainerToken(string $dataContainerObjectUrl): ?string
     {
-        $options = [
+        $options = array_merge([
             RequestOptions::ALLOW_REDIRECTS => false,
-        ];
+        ], $this->guzzleConfig);
 
         try {
-            $client = new Client([
-                'base_uri' => $dataContainerObjectUrl,
-            ]);
-
-            $response     = $client->request('GET', '', $options);
+            $response     = $this->guzzleClient->request('GET', $dataContainerObjectUrl, $options);
             $cookieHeader = $response->getHeader('Set-Cookie');
 
             if ($sessionToken = reset($cookieHeader)) {

--- a/src/HttpClient/Connector.php
+++ b/src/HttpClient/Connector.php
@@ -22,7 +22,7 @@ class Connector
     public function __construct(
         private string                     $configHost,
         protected CacheRepositoryInterface $cache,
-        private array  $guzzleConfig  = []
+        private array                      $guzzleConfig = []
     )
     {
         $this->baseUrl = $this->getBaseUri();
@@ -33,7 +33,7 @@ class Connector
 
         $this->guzzleClient = new Client(array_merge([
             'base_uri' => $this->baseUrl,
-          ], $guzzleConfig));
+        ], $guzzleConfig));
     }
 
     public function get(string $uri, ?string $sessionToken = null, array $query = []): ResponseInterface

--- a/src/RecordRepository/FmBaseObject.php
+++ b/src/RecordRepository/FmBaseObject.php
@@ -2,21 +2,22 @@
 
 namespace Flooris\FileMakerDataApi\RecordRepository;
 
+use stdClass;
 use Flooris\FileMakerDataApi\Exceptions\FilemakerDataApiConfigInvalidConnectionException;
 
 abstract class FmBaseObject
 {
     public int $recordId;
     public int $modId;
-    public ?\stdClass $fieldData;
-    public ?\stdClass $portalData;
+    public ?stdClass $fieldData;
+    public ?stdClass $portalData;
 
     /**
      * ToDo: Move this abstract class to the Laravel package
      */
 
     public function __construct(
-        \stdClass                $fmResultObject,
+        stdClass                $fmResultObject,
         public ?FmBaseRepository $repository = null,
     )
     {

--- a/src/RecordRepository/FmBasePortalObject.php
+++ b/src/RecordRepository/FmBasePortalObject.php
@@ -2,20 +2,21 @@
 
 namespace Flooris\FileMakerDataApi\RecordRepository;
 
+use stdClass;
 use Flooris\FileMakerDataApi\Exceptions\FilemakerDataApiConfigInvalidConnectionException;
 
 abstract class FmBasePortalObject
 {
     public int $recordId;
     public int $modId;
-    public ?\stdClass $fieldData;
+    public ?stdClass $fieldData;
 
     /**
      * ToDo: Move this abstract class to the Laravel package
      */
 
     public function __construct(
-        \stdClass $fmResultObject
+        stdClass $fmResultObject
     )
     {
         $this->recordId  = (int)$fmResultObject->recordId;

--- a/src/RecordRepository/FmBaseRepository.php
+++ b/src/RecordRepository/FmBaseRepository.php
@@ -2,6 +2,8 @@
 
 namespace Flooris\FileMakerDataApi\RecordRepository;
 
+use stdClass;
+use Exception;
 use Flooris\FileMakerDataApi\Client;
 use Psr\Http\Message\StreamInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -10,7 +12,7 @@ use Psr\SimpleCache\InvalidArgumentException;
 abstract class FmBaseRepository
 {
     public bool $findRequestFailed = false;
-    public ?\Exception $lastException = null;
+    public ?Exception $lastException = null;
     public int $totalRecordCount = 0;
     public int $foundCount = 0;
     public int $currentResultCount = 0;
@@ -35,7 +37,7 @@ abstract class FmBaseRepository
         ]);
     }
 
-    public function findRecordById(int $id): ?\stdClass
+    public function findRecordById(int $id): ?stdClass
     {
         try {
             $fmDataRecords = $this->findRecords($this->getFindQueryById($id));
@@ -58,7 +60,7 @@ abstract class FmBaseRepository
                 ->fmClient
                 ->record($this->fmLayoutName)
                 ->findRecords($findQuery, $offset, $limit, $sort);
-        } catch (\Exception|InvalidArgumentException $exception) {
+        } catch (Exception|InvalidArgumentException $exception) {
             $this->findRequestFailed = true;
             $this->lastException     = $exception;
 


### PR DESCRIPTION
# Date format and session ttl support from configuration
## linked issues
- [Configuration with .env](https://github.com/flooris/filemaker-data-api/issues/7)

## Description
currently there is no way to influence for how long the session token is stored. Beside that There is also an issue that depending on the environment of the filemaker server the date format can change. With these changes you can put the needed context in the environment variables and retrieve it from the config.

## changes
- added fields for date format and session ttl in config
- created function for retrieving ttl from config
- replaced hardcoded TTL with the new function that will get it from the config
- updated connector for media & token requests to use same guzzle client instance as the rest of the package

## Version
- `2.2.0` -> `2.2.1` a patch level change due to it only adding possible env values and it does not change the current interface that the developers interact with
