### PR TITLE
feature make cookie token optional

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -141,7 +141,7 @@ class Client
     /**
      * @throws GuzzleException
      */
-    public function getDataContainerContent(string $dataContainerObjectUrl, string $dataContainerToken): ?StreamInterface
+    public function getDataContainerContent(string $dataContainerObjectUrl, ?string $dataContainerToken = null): ?StreamInterface
     {
         return $this->connector->getDataContainerContent($dataContainerObjectUrl, $dataContainerToken);
     }

--- a/src/HttpClient/Connector.php
+++ b/src/HttpClient/Connector.php
@@ -22,7 +22,7 @@ class Connector
         private string                     $configHost,
         protected CacheRepositoryInterface $cache,
         private array                      $guzzleConfig = []
-    ) 
+    )
     {
         $this->baseUrl = $this->getBaseUri();
 

--- a/src/HttpClient/Connector.php
+++ b/src/HttpClient/Connector.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Flooris\FileMakerDataApi\HttpClient;
 
 use GuzzleHttp\Client;
@@ -23,7 +22,7 @@ class Connector
         private string                     $configHost,
         protected CacheRepositoryInterface $cache,
         private array                      $guzzleConfig = []
-    )
+    ) 
     {
         $this->baseUrl = $this->getBaseUri();
 
@@ -78,16 +77,19 @@ class Connector
     /**
      * @throws GuzzleException
      */
-    public function getDataContainerContent(string $dataContainerObjectUrl, string $dataContainerToken): ?StreamInterface
+    public function getDataContainerContent(string $dataContainerObjectUrl, ?string $dataContainerToken): ?StreamInterface
     {
+        $extraOptions = [];
 
-        $options = array_merge([
-            RequestOptions::HEADERS => [
+        if($dataContainerToken) {
+            $extraOptions[RequestOptions::HEADERS] =  [
                 'Cookie' => [
                     $dataContainerToken,
                 ],
-            ],
-        ], $this->guzzleConfig);
+            ];
+        }
+
+        $options = array_merge($extraOptions, $this->guzzleConfig);
 
         $response = $this->guzzleClient->request('GET', $dataContainerObjectUrl, $options);
 
@@ -120,13 +122,14 @@ class Connector
         $protocol = config(sprintf('filemaker.%s.protocol', $this->configHost));
         $host     = config(sprintf('filemaker.%s.hostname', $this->configHost));
 
-        if (! $protocol ||
-            ! $host
+        if (!$protocol ||
+            !$host
         ) {
             return null;
         }
 
-        return sprintf('%s%s%s/',
+        return sprintf(
+            '%s%s%s/',
             $protocol,
             $host,
             $port ? ":{$port}" : '',
@@ -169,7 +172,7 @@ class Connector
     {
         $config = config(sprintf('filemaker.%s', $this->configHost));
 
-        if (! $config) {
+        if (!$config) {
             throw new FilemakerDataApiConfigHostMissingException($this->configHost);
         }
 
@@ -182,7 +185,7 @@ class Connector
                 continue;
             }
 
-            if (! $configValue && $throwException) {
+            if (!$configValue && $throwException) {
                 throw new FilemakerDataApiConfigInvalidConnectionException("The key {$configKey} has no value");
             }
         }


### PR DESCRIPTION
# feature make cookie token optional

## Post release
- release version`2.2.8`

## Description
you do not always need the cookie token to pass to the content container fetch function. So make it optional

## Changelog
- made cookie token optional for content container
- updated paramaters to make it optional